### PR TITLE
Use loadReactions directly instead of loadFromPackage

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/App.java
+++ b/src/main/java/com/github/splendor_mobile_game/App.java
@@ -2,17 +2,24 @@ package com.github.splendor_mobile_game;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import com.github.splendor_mobile_game.config.Config;
 import com.github.splendor_mobile_game.config.EnvConfig;
 import com.github.splendor_mobile_game.config.exceptions.InvalidConfigException;
 import com.github.splendor_mobile_game.handlers.ReactionManager;
 import com.github.splendor_mobile_game.handlers.connection.ConnectionHandlerImpl;
+import com.github.splendor_mobile_game.handlers.reactions.CreateServer;
 import com.github.splendor_mobile_game.utils.Log;
 import com.github.splendor_mobile_game.websocket.ConnectionHandlerWithoutDefaultConstructorException;
 import com.github.splendor_mobile_game.websocket.WebSocketSplendorServer;
 
 public class App {
+
+    private static List<Class<?>> classesWithReactions = new ArrayList<>(Arrays.asList(
+            CreateServer.class));
 
     public static void main(String[] args)
             throws InvalidConfigException, IOException, ConnectionHandlerWithoutDefaultConstructorException {
@@ -25,7 +32,7 @@ public class App {
 
         // Define where are reactions to the messages from client and load these reactions
         ReactionManager reactionManager = new ReactionManager();
-        reactionManager.loadFromPackage("com.github.splendor_mobile_game.handlers.reactions");
+        reactionManager.loadReactions(App.classesWithReactions);
 
         // Setup the server
         int port = config.getPort();

--- a/src/main/java/com/github/splendor_mobile_game/handlers/ReactionManager.java
+++ b/src/main/java/com/github/splendor_mobile_game/handlers/ReactionManager.java
@@ -13,34 +13,68 @@ import java.util.Map;
 import com.github.splendor_mobile_game.utils.Log;
 import com.github.splendor_mobile_game.utils.reflection.Reflection;
 
+/**
+ * The `ReactionManager` class manages the loading and storage of `Reaction` classes..
+ */
 public class ReactionManager {
+
+    /**
+     * A `Map` of reaction names to their corresponding `Reaction` classes.
+     */
     public Map<String, Class<? extends Reaction>> reactions = new HashMap<>();
+
+    /**
+     * The package to search in when loading `Reaction` classes.
+     */
     private String packageToSearchIn;
 
+    /**
+     * Creates a new `ReactionManager` instance with an empty `reactions` map and a `null` `packageToSearchIn`.
+     */
     public ReactionManager() {
+
     }
 
+    /**
+     * Creates a new `ReactionManager` instance and automatically loads `Reaction` classes from the specified package.
+     *
+     * @param packageToSearchIn the full domain name of the package to search for classes
+     * @throws IOException if an I/O error occurs while searching for classes
+     */
     public ReactionManager(String packageToSearchIn) throws IOException {
         this.packageToSearchIn = packageToSearchIn;
         this.loadFromPackage(this.packageToSearchIn);
     }
 
+    /**
+    * Searches for classes in the specified package and loads reactions from them.
+    * This function might not work if your project is on non system partition.
+    * 
+    * @deprecated
+    * @param packageName the full domain name of the package to search for classes
+    * @throws IOException if an I/O error occurs while searching for classes
+    */
     public void loadFromPackage(String packageName) throws IOException {
+        // Set the package to search in
         this.packageToSearchIn = packageName;
 
+        // Get the class loader and package path
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         String path = packageName.replace('.', '/');
+
+        // Find all class files in the package
         List<Class<?>> classes = new ArrayList<>();
-
         Enumeration<URL> resources = classLoader.getResources(path);
-
         while (resources.hasMoreElements()) {
             URL resource = resources.nextElement();
             File file = new File(resource.getFile());
 
-            if (!file.isDirectory())
+            // Skip non-directories
+            if (!file.isDirectory()) {
                 continue;
+            }
 
+            // Add classes to the list
             for (File classFile : file.listFiles()) {
                 String className = packageName + "." + classFile.getName().replace(".class", "");
                 Class<?> clazz;
@@ -56,19 +90,29 @@ public class ReactionManager {
             }
         }
 
+        // Load the reactions from the classes
         this.loadReactions(classes);
     }
 
-    private void loadReactions(List<Class<?>> classesToSearchIn) {
+    /**
+    * Loads reactions from the provided list of classes. Only classes that implement the Reaction interface and have a
+    * public constructor with a single int parameter will be loaded.
+    *
+    * @param classesToSearchIn the list of classes to search for reactions
+    */
+    public void loadReactions(List<Class<?>> classesToSearchIn) {
+        // Check if the list of classes is null
         if (classesToSearchIn == null) {
             Log.ERROR("Cannot load reaction, because provided list of classes has not been initialized and is null!");
             return;
         }
 
+        // Iterate over the classes and load reactions
         for (Class<?> clazz : classesToSearchIn) {
             Class<? extends Reaction> reactionClass;
 
             try {
+                // Check if the class implements the Reaction interface
                 reactionClass = clazz.asSubclass(Reaction.class);
             } catch (ClassCastException e) {
                 // Log.WARNING(clazz.getName() + " doesn't implement interface `Reaction`, but is in package `"
@@ -76,6 +120,7 @@ public class ReactionManager {
                 continue;
             }
 
+            // Check if the class has a public constructor with a single int parameter
             if (!Reflection.hasOneParameterConstructor(clazz, int.class)) {
                 Log.ERROR(
                         clazz.getName()
@@ -83,11 +128,13 @@ public class ReactionManager {
                 continue;
             }
 
+            // Check if the class is public
             if (!Modifier.isPublic(clazz.getModifiers())) {
                 Log.ERROR(clazz.getName() + " was not registered as the Reaction because it's not public!");
                 continue;
             }
 
+            // Add the reaction to the map
             String simpleName = clazz.getName().substring(clazz.getName().lastIndexOf(".") + 1);
             this.reactions.put(simpleName, reactionClass);
 


### PR DESCRIPTION
Function `loadFromPackage` is not reliant. @Vertonowsky had noticed that it doesn't work on his machine when project is on a non system partition. So we decided that `loadFromPackage` should not be used, instead use `loadReaction `with classes to load as a parameter, which will incur in more explicit code and more boilerplate in the `App `class, but it definitely works.