### PR TITLE
Move reaction's parameters to its constructor

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
@@ -144,15 +144,15 @@ public class WebSocketSplendorServer extends WebSocketServer {
         // Create instance of this reactionClass
         Reaction reactionInstance;
         try {
-            reactionInstance = (Reaction) Reflection.createInstanceOfClass(reactionClass, webSocket.hashCode(), messenger, this.database);
+            reactionInstance = (Reaction) Reflection.createInstanceOfClass(reactionClass, webSocket.hashCode(), receivedMessage, messenger, this.database);
         } catch (CannotCreateInstanceException e) {
             Log.ERROR(e.getMessage());
             e.printStackTrace();
             return;
         }
 
-        // Use it to obtain appropriate reply
-        reactionInstance.react(receivedMessage);
+        // Use it to react appropriately
+        reactionInstance.react();
 
         // And send it to the users
         for (Message messageToSend : messenger.getMessages()) {

--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
@@ -139,20 +139,20 @@ public class WebSocketSplendorServer extends WebSocketServer {
             return;
         }
 
+        Messenger messenger = new Messenger();
+
         // Create instance of this reactionClass
         Reaction reactionInstance;
         try {
-            reactionInstance = (Reaction) Reflection.createInstanceOfClass(reactionClass, webSocket.hashCode());
+            reactionInstance = (Reaction) Reflection.createInstanceOfClass(reactionClass, webSocket.hashCode(), messenger, this.database);
         } catch (CannotCreateInstanceException e) {
             Log.ERROR(e.getMessage());
             e.printStackTrace();
             return;
         }
 
-        Messenger messenger = new Messenger();
-
         // Use it to obtain appropriate reply
-        reactionInstance.react(receivedMessage, messenger, this.database);
+        reactionInstance.react(receivedMessage);
 
         // And send it to the users
         for (Message messageToSend : messenger.getMessages()) {

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/Reaction.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/Reaction.java
@@ -6,10 +6,14 @@ import com.github.splendor_mobile_game.websocket.communication.ReceivedMessage;
 public abstract class Reaction {
 
     protected int connectionHashCode;
+    protected Messenger messenger;
+    protected Database database;
 
-    public Reaction(int connectionHashCode) {
+    public Reaction(int connectionHashCode, Messenger messenger, Database database) {
         this.connectionHashCode = connectionHashCode;
+        this.messenger = messenger;
+        this.database = database;
     }
 
-    public abstract void react(ReceivedMessage parsedMessage, Messenger messenger, Database database);
+    public abstract void react(ReceivedMessage parsedMessage);
 }

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/Reaction.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/Reaction.java
@@ -8,12 +8,14 @@ public abstract class Reaction {
     protected int connectionHashCode;
     protected Messenger messenger;
     protected Database database;
+    protected ReceivedMessage receivedMessage;
 
-    public Reaction(int connectionHashCode, Messenger messenger, Database database) {
+    public Reaction(int connectionHashCode, ReceivedMessage receivedMessage, Messenger messenger, Database database) {
         this.connectionHashCode = connectionHashCode;
+        this.receivedMessage = receivedMessage;
         this.messenger = messenger;
         this.database = database;
     }
 
-    public abstract void react(ReceivedMessage parsedMessage);
+    public abstract void react();
 }

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.splendor_mobile_game.database.Database;
+import com.github.splendor_mobile_game.websocket.communication.ReceivedMessage;
 import com.github.splendor_mobile_game.websocket.utils.Log;
 import com.github.splendor_mobile_game.websocket.utils.reflection.Reflection;
 
@@ -124,10 +125,10 @@ public class ReactionManager {
 
             // Check if the class has a public constructor with appropriate parameters
             try {
-                Reflection.getConstructorWithParameters(clazz, int.class, Messenger.class, Database.class);
+                Reflection.getConstructorWithParameters(clazz, int.class, ReceivedMessage.class, Messenger.class, Database.class);
             } catch (NoSuchMethodException e) {
                 Log.ERROR(clazz.getName() + " was not registered as the Reaction, because it doesn't" 
-                    + " implement constructor with `int`, `Messenger` and `Database`, but it's required!"
+                    + " implement constructor with `int`, `ReceivedMessage`, `Messenger` and `Database`, but it's required!"
                 );
             }
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.github.splendor_mobile_game.database.Database;
 import com.github.splendor_mobile_game.websocket.utils.Log;
 import com.github.splendor_mobile_game.websocket.utils.reflection.Reflection;
 
@@ -121,12 +122,13 @@ public class ReactionManager {
                 continue;
             }
 
-            // Check if the class has a public constructor with a single int parameter
-            if (!Reflection.hasOneParameterConstructor(clazz, int.class)) {
-                Log.ERROR(
-                        clazz.getName()
-                                + " was not registered as the Reaction, beacause it doesn't implement constructor with `int` as the only parameter which is required!");
-                continue;
+            // Check if the class has a public constructor with appropriate parameters
+            try {
+                Reflection.getConstructorWithParameters(clazz, int.class, Messenger.class, Database.class);
+            } catch (NoSuchMethodException e) {
+                Log.ERROR(clazz.getName() + " was not registered as the Reaction, because it doesn't" 
+                    + " implement constructor with `int`, `Messenger` and `Database`, but it's required!"
+                );
             }
 
             // Check if the class is public

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
@@ -20,8 +20,8 @@ import com.google.gson.JsonObject;
 
 public class CreateRoom extends Reaction {
 
-    public CreateRoom(int connectionHashCode, Messenger messenger, Database database) {
-        super(connectionHashCode, messenger, database);
+    public CreateRoom(int connectionHashCode, ReceivedMessage receivedMessage, Messenger messenger, Database database) {
+        super(connectionHashCode, receivedMessage, messenger, database);
     }
 
     private class RoomDTO {
@@ -59,32 +59,32 @@ public class CreateRoom extends Reaction {
      */
 
     @Override
-    public void react(ReceivedMessage parsedMessage) {
+    public void react() {
 
-        DataDTO receivedMessage = (DataDTO) parsedMessage.getData();
+        DataDTO dataDTO = (DataDTO) receivedMessage.getData();
 
         try {
-            validateData(receivedMessage);
+            validateData(dataDTO);
 
-            User user = new User(receivedMessage.userDTO.id, receivedMessage.userDTO.name, this.connectionHashCode);
-            Room room = new Room(UUID.randomUUID(), receivedMessage.roomDTO.name, receivedMessage.roomDTO.password, user);
+            User user = new User(dataDTO.userDTO.id, dataDTO.userDTO.name, this.connectionHashCode);
+            Room room = new Room(UUID.randomUUID(), dataDTO.roomDTO.name, dataDTO.roomDTO.password, user);
 
             database.addUser(user);
             database.addRoom(room);
 
             JsonObject userJson = new JsonObject();
-            userJson.addProperty("id", receivedMessage.userDTO.id.toString());
-            userJson.addProperty("name", receivedMessage.userDTO.name);
+            userJson.addProperty("id", dataDTO.userDTO.id.toString());
+            userJson.addProperty("name", dataDTO.userDTO.name);
 
             JsonObject roomJson = new JsonObject();
-            roomJson.addProperty("name", receivedMessage.roomDTO.name);
+            roomJson.addProperty("name", dataDTO.roomDTO.name);
 
             JsonObject data = new JsonObject();
             data.add("user", userJson);
             data.add("room", roomJson);
 
             JsonObject response = new JsonObject();
-            response.addProperty("messageContextId", parsedMessage.getMessageContextId());
+            response.addProperty("messageContextId", receivedMessage.getMessageContextId());
             response.addProperty("type", "CreateRoomResponse");
             response.addProperty("result", "OK");
             response.add("data", data);
@@ -97,7 +97,7 @@ public class CreateRoom extends Reaction {
                 Result.FAILURE, 
                 e.getMessage(), 
                 "CreateRoomResponse",
-                parsedMessage.getMessageContextId()
+                receivedMessage.getMessageContextId()
             );
 
             messenger.addMessageToSend(connectionHashCode, errorResponse.ToJson());

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
@@ -20,8 +20,8 @@ import com.google.gson.JsonObject;
 
 public class CreateRoom extends Reaction {
 
-    public CreateRoom(int connectionHashCode) {
-        super(connectionHashCode);
+    public CreateRoom(int connectionHashCode, Messenger messenger, Database database) {
+        super(connectionHashCode, messenger, database);
     }
 
     private class RoomDTO {
@@ -59,7 +59,7 @@ public class CreateRoom extends Reaction {
      */
 
     @Override
-    public void react(ReceivedMessage parsedMessage, Messenger messenger, Database database) {
+    public void react(ReceivedMessage parsedMessage) {
 
         DataDTO receivedMessage = (DataDTO) parsedMessage.getData();
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateServer.java
@@ -16,8 +16,8 @@ public class CreateServer extends Reaction {
     // This field is available due to abstract class
     // protected int connectionHashCode;
 
-    public CreateServer(int connectionHashCode) {
-        super(connectionHashCode);
+    public CreateServer(int connectionHashCode, Messenger messenger, Database database) {
+        super(connectionHashCode, messenger, database);
     }
 
     public class Player {
@@ -30,7 +30,7 @@ public class CreateServer extends Reaction {
     }
 
     @Override
-    public void react(ReceivedMessage input, Messenger messenger, Database database) {
+    public void react(ReceivedMessage input) {
         // Received request from the client should be in the following format
         // {
         //     "messageContextId": "80bdc250-5365-4caf-8dd9-a33e709a0116",

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateServer.java
@@ -16,8 +16,8 @@ public class CreateServer extends Reaction {
     // This field is available due to abstract class
     // protected int connectionHashCode;
 
-    public CreateServer(int connectionHashCode, Messenger messenger, Database database) {
-        super(connectionHashCode, messenger, database);
+    public CreateServer(int connectionHashCode, ReceivedMessage receivedMessage, Messenger messenger, Database database) {
+        super(connectionHashCode, receivedMessage, messenger, database);
     }
 
     public class Player {
@@ -30,7 +30,7 @@ public class CreateServer extends Reaction {
     }
 
     @Override
-    public void react(ReceivedMessage input) {
+    public void react() {
         // Received request from the client should be in the following format
         // {
         //     "messageContextId": "80bdc250-5365-4caf-8dd9-a33e709a0116",
@@ -67,25 +67,11 @@ public class CreateServer extends Reaction {
         //     }
         // }
 
-        // String message = "{\"type\":\"CreateServer\"}";
-
-        Data receivedMessage = (Data) input.getData();
-        // Try to parse to ReceivedMessage object if fail then print what fields are missing
-        // try {
-        //     receivedMessage = com.github.splendor_mobile_game.websocket.utils.json.JsonParser.parseJson(input.getData().toString(),
-        //             Data.class);
-        // } catch (Exception e) {
-        //     Log.ERROR(e.toString());
-        //     ErrorResponse response = new ErrorResponse(Result.FAILURE, e.getMessage(), "CreateServerResponse");
-        //     return response.ToJson();
-        // }
-
-        // TODO: Add player to some database or other structure in ram
-        // TODO: Create some gameSession
+        Data dataDTO = (Data) receivedMessage.getData();
 
         JsonObject player = new JsonObject();
         player.addProperty("id", UUID.randomUUID().toString());
-        player.addProperty("name", receivedMessage.player.name);
+        player.addProperty("name", dataDTO.player.name);
 
         JsonObject data = new JsonObject();
         data.addProperty("roomCode", RandomString.generateRandomString(5));
@@ -93,7 +79,7 @@ public class CreateServer extends Reaction {
         data.add("player", player);
 
         JsonObject response = new JsonObject();
-        response.addProperty("messageContextId", input.getMessageContextId());
+        response.addProperty("messageContextId", receivedMessage.getMessageContextId());
         response.addProperty("type", "CreateServerResponse");
         response.addProperty("result", "OK");
         response.add("data", data);

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/JoinRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/JoinRoom.java
@@ -11,8 +11,8 @@ import com.google.gson.JsonObject;
 
 public class JoinRoom extends Reaction {
 
-    public JoinRoom(int connectionHashCode) {
-        super(connectionHashCode);
+    public JoinRoom(int connectionHashCode, Messenger messenger, Database database) {
+        super(connectionHashCode, messenger, database);
     }
 
     @DataClass
@@ -23,7 +23,7 @@ public class JoinRoom extends Reaction {
     }
 
     @Override
-    public void react(ReceivedMessage parsedMessage, Messenger messenger, Database database) {
+    public void react(ReceivedMessage parsedMessage) {
 
         Data data = (Data) parsedMessage.getData();
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/JoinRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/JoinRoom.java
@@ -11,8 +11,8 @@ import com.google.gson.JsonObject;
 
 public class JoinRoom extends Reaction {
 
-    public JoinRoom(int connectionHashCode, Messenger messenger, Database database) {
-        super(connectionHashCode, messenger, database);
+    public JoinRoom(int connectionHashCode, ReceivedMessage receivedMessage, Messenger messenger, Database database) {
+        super(connectionHashCode, receivedMessage, messenger, database);
     }
 
     @DataClass
@@ -23,9 +23,9 @@ public class JoinRoom extends Reaction {
     }
 
     @Override
-    public void react(ReceivedMessage parsedMessage) {
+    public void react() {
 
-        Data data = (Data) parsedMessage.getData();
+        Data data = (Data) receivedMessage.getData();
 
         JsonObject player = new JsonObject();
         player.addProperty("id", connectionHashCode);
@@ -37,7 +37,7 @@ public class JoinRoom extends Reaction {
         room.add("player", player);
 
         JsonObject response = new JsonObject();
-        response.addProperty("messageContextId", parsedMessage.getMessageContextId());
+        response.addProperty("messageContextId", receivedMessage.getMessageContextId());
         response.addProperty("type", "JoinRoomResponse");
         response.addProperty("result", "OK");
         response.add("data", room);

--- a/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
@@ -27,6 +27,39 @@ public class Reflection {
         }
     }
 
+    public static Constructor<?> getConstructorWithParameters(Class<?> clazz, Class<?>... parameters) throws NoSuchMethodException {
+        Class<?>[] parameterTypes = new Class[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            parameterTypes[i] = parameters[i];
+        }
+
+        Constructor<?>[] constructors = clazz.getConstructors();
+        
+        for (int i = 0; i < constructors.length; i++) {
+            Class<?>[] constructorParameters = constructors[i].getParameterTypes();
+
+            if (constructorParameters.length != parameterTypes.length) {
+                continue;
+            }
+
+            int j;
+            for (j = 0; j < parameterTypes.length; j++) {
+                Class<?> parameter1 = toSimpleType(constructorParameters[j]);
+                Class<?> parameter2 = toSimpleType(parameterTypes[j]);
+                if (!parameter1.isAssignableFrom(parameter2)) {
+                    // Log.DEBUG(constructorParameters[j].getName() + "-" + parameters[j].getName());
+                    break;
+                }
+            }
+            
+            if (j == parameterTypes.length) {
+                return constructors[i];
+            }
+        }
+
+        throw new NoSuchMethodException();
+    }
+
     public static Class<?> findClassWithAnnotationWithinClass(Class<?> parent, Class<? extends Annotation> annotation) {
         for (Class<?> clazz : parent.getDeclaredClasses())
             if (clazz.isAnnotationPresent(annotation))
@@ -41,7 +74,7 @@ public class Reflection {
 
         try {
             paremeterTypes = Reflection.getParameterTypes(constructorArgs);
-            Constructor<?> constructor = clazz.getDeclaredConstructor(paremeterTypes);
+            Constructor<?> constructor = Reflection.getConstructorWithParameters(clazz, paremeterTypes);
             return constructor.newInstance(constructorArgs);
 
         } catch (Exception e) {


### PR DESCRIPTION
`Reaction` has a function `react` which takes currently 3 arguments `ReceivedMessage parsedMessage, Messenger messenger, Database database` . I think that we move `Messenger` and `Database` into constructor of the Reaction.

Actually.. We can move `ReceiveMessage` into constructor as well. What do you think about that?