### PR TITLE
Feature/custom reaction type name

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
@@ -135,11 +135,21 @@ public class ReactionManager {
                 continue;
             }
 
-            // Add the reaction to the map
-            String simpleName = clazz.getName().substring(clazz.getName().lastIndexOf(".") + 1);
-            this.reactions.put(simpleName, reactionClass);
+            // Get the custom name of the reaction if ReactionName annotation is used
+            // else use the class name
+            ReactionName reactionNameAnnotation = clazz.getAnnotation(ReactionName.class);
+            String reactionNameString;
 
-            Log.INFO("Class `" + clazz.getName() + "` loaded as `" + simpleName + "`");
+            if (reactionNameAnnotation == null) {
+                // Log.WARNING(clazz.getName() + " doesn't have ReactionName annotation, so it'll be registered with the name of its class!");
+                reactionNameString = clazz.getName().substring(clazz.getName().lastIndexOf(".") + 1);
+            } else {
+                reactionNameString = reactionNameAnnotation.value();
+            }
+
+            // Add the reaction to the map
+            this.reactions.put(reactionNameString, reactionClass);
+            Log.INFO("Class `" + clazz.getName() + "` loaded as `" + reactionNameString + "`");
         }
     }
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionName.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionName.java
@@ -1,0 +1,12 @@
+package com.github.splendor_mobile_game.websocket.handlers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ReactionName {
+    String value();
+}

--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
@@ -13,11 +13,13 @@ import com.github.splendor_mobile_game.websocket.communication.ReceivedMessage;
 import com.github.splendor_mobile_game.websocket.handlers.DataClass;
 import com.github.splendor_mobile_game.websocket.handlers.Messenger;
 import com.github.splendor_mobile_game.websocket.handlers.Reaction;
+import com.github.splendor_mobile_game.websocket.handlers.ReactionName;
 import com.github.splendor_mobile_game.websocket.response.ErrorResponse;
 import com.github.splendor_mobile_game.websocket.response.Result;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
+@ReactionName("CREATE_ROOM")
 public class CreateRoom extends Reaction {
 
     public CreateRoom(int connectionHashCode) {
@@ -44,7 +46,7 @@ public class CreateRoom extends Reaction {
     /*
     {
          "messageContextId": "80bdc250-5365-4caf-8dd9-a33e709a0116",
-         "type": "CreateRoom",
+         "type": "CREATE_ROOM",
          "data": {
              "userDTO": {
                  "id": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
@@ -85,7 +87,7 @@ public class CreateRoom extends Reaction {
 
             JsonObject response = new JsonObject();
             response.addProperty("messageContextId", parsedMessage.getMessageContextId());
-            response.addProperty("type", "CreateRoomResponse");
+            response.addProperty("type", "CREATE_ROOM_RESPONSE");
             response.addProperty("result", "OK");
             response.add("data", data);
 
@@ -96,7 +98,7 @@ public class CreateRoom extends Reaction {
             ErrorResponse errorResponse = new ErrorResponse(
                 Result.FAILURE, 
                 e.getMessage(), 
-                "CreateRoomResponse",
+                "CREATE_ROOM_RESPONSE",
                 parsedMessage.getMessageContextId()
             );
 


### PR DESCRIPTION
Now reaction can have custom name when you use `ReactionName` annotation.

Currently when client sends requests to the server, server handles the message. Message is redirected to appropriate reaction based on the reaction class name. Now message type can be independent from the class name by using `ReactionName` annotation.

See `CreateRoom` class with the first example of using it.