### PR TITLE
Add example of ResponseClass annotation

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/reactions/CreateRoom.java
@@ -47,6 +47,68 @@ public class CreateRoom extends Reaction {
         public RoomDTO roomDTO;
     }
 
+    @ResponseClass
+    private class Response {
+        UUID messageContextId;
+        String type;
+        Result result;
+        ResponseData data;
+
+        public Response(UUID messageContextId, String type, Result result, ResponseData data) {
+            this.messageContextId = messageContextId;
+            this.type = type;
+            this.result = result;
+            this.data = data;
+        }
+
+    }
+
+    private class ResponseData {
+        UserDataResponse user;
+        RoomDataResponse room;
+
+        public ResponseData(UserDataResponse user, RoomDataResponse room) {
+            this.user = user;
+            this.room = room;
+        }
+        
+    }
+
+    private class UserDataResponse {
+        public UUID id;
+        public String name;
+
+        public UserDataResponse(UUID id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+        
+    }
+
+    private class RoomDataResponse {
+        String name;
+
+        public RoomDataResponse(String name) {
+            this.name = name;
+        }
+
+    }
+
+    // {
+    //     "messageContextId":"80bdc250-5365-4caf-8dd9-a33e709a0116",
+    //     "type":"CREATE_ROOM_RESPONSE",
+    //     "result":"OK",
+    //     "data":{
+    //         "user":{
+    //             "id":"f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
+    //             "name":"James"
+    //         },
+    //         "room":{
+    //             "name":"TajnyPokoj"
+    //         }
+    //     }
+    // }
+
     /*   ----> EXAMPLE USER REQUEST <----
     {
          "messageContextId": "80bdc250-5365-4caf-8dd9-a33e709a0116",
@@ -80,24 +142,12 @@ public class CreateRoom extends Reaction {
             database.addUser(user);
             database.addRoom(room);
 
-            JsonObject userJson = new JsonObject();
-            userJson.addProperty("id", dataDTO.userDTO.uuid.toString());
-            userJson.addProperty("name", dataDTO.userDTO.name);
+            UserDataResponse userDataResponse = new UserDataResponse(dataDTO.userDTO.uuid, dataDTO.userDTO.name);
+            RoomDataResponse roomDataResponse = new RoomDataResponse(dataDTO.roomDTO.name);
+            ResponseData responseData = new ResponseData(userDataResponse, roomDataResponse);
+            Response response = new Response(UUID.fromString(receivedMessage.getMessageContextId()), ResponseType.CREATE_ROOM_RESPONSE.toString(), Result.OK, responseData);
 
-            JsonObject roomJson = new JsonObject();
-            roomJson.addProperty("name", dataDTO.roomDTO.name);
-
-            JsonObject data = new JsonObject();
-            data.add("user", userJson);
-            data.add("room", roomJson);
-
-            JsonObject response = new JsonObject();
-            response.addProperty("messageContextId", receivedMessage.getMessageContextId());
-            response.addProperty("type", ResponseType.CREATE_ROOM_RESPONSE.toString());
-            response.addProperty("result", Result.OK.toString());
-            response.add("data", data);
-
-            messenger.addMessageToSend(this.connectionHashCode, (new Gson()).toJson(response));
+            messenger.addMessageToSend(this.connectionHashCode, response);
 
         } catch (Exception e) {
             ErrorResponse errorResponse = new ErrorResponse(Result.FAILURE, e.getMessage(), ResponseType.CREATE_ROOM_RESPONSE, receivedMessage.getMessageContextId());


### PR DESCRIPTION
#21 

**Warning: This code doesn't compile!**

I added the proposal about using such data classes, how it would look like in the reaction class. This is only first try. Names are horrible at the moment. I'm open to changes.

The reaction class can have now nested class with `@ResponseClass` annotation. This nested class defines the response to the user in `OK` case. 

By doing this, we have more concise code in creating the response to the user, instead of creating Json string all ourselves with JsonObject class etc. 

Disadvantage of this is, that we have to define nested classes for the response and that takes some space.