### PR TITLE
Data field not required in requests if there is no dataclass

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/ReceivedMessage.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/ReceivedMessage.java
@@ -1,12 +1,14 @@
 package com.github.splendor_mobile_game.websocket.communication;
 
 import com.github.splendor_mobile_game.websocket.utils.json.JsonParser;
+import com.github.splendor_mobile_game.websocket.utils.json.Optional;
 import com.github.splendor_mobile_game.websocket.utils.json.exceptions.JsonParserException;
 import com.google.gson.Gson;
 
 public class ReceivedMessage {
     private String messageContextId;
     private String type;
+    @Optional
     private Object data;
 
     public ReceivedMessage(String message) throws InvalidReceivedMessage {

--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
@@ -131,12 +131,21 @@ public class WebSocketSplendorServer extends WebSocketServer {
 
         // Parse the data given in the message
         Class<?> dataClass = Reflection.findClassWithAnnotationWithinClass(reactionClass, DataClass.class);
-        try {
-            receivedMessage.parseDataToClass(dataClass);
-        } catch (InvalidReceivedMessage e) {
-            Log.ERROR(e.toString());
-            webSocket.send(e.toJsonResponse());
-            return;
+
+        if (dataClass != null) {
+            try {
+                receivedMessage.parseDataToClass(dataClass);
+            } catch (InvalidReceivedMessage e) {
+                Log.ERROR(e.toString());
+                webSocket.send(e.toJsonResponse());
+                return;
+            }
+        }
+
+        if (dataClass == null && receivedMessage.getData() != null) {
+            Log.WARNING(webSocket.hashCode() + 
+                " provided data to the message, but the message type reaction class doesn't require any data!"
+            );
         }
 
         Messenger messenger = new Messenger();
@@ -170,6 +179,9 @@ public class WebSocketSplendorServer extends WebSocketServer {
     @Override
     public void onError(WebSocket webSocket, Exception e) {
         Log.ERROR("Server error: " + e.getMessage());
+        // TODO: Messaage type and message id
+        ErrorResponse response = new ErrorResponse(Result.ERROR, e.getMessage());
+        webSocket.send(response.ToJson());
     }
 
 }

--- a/src/main/java/com/github/splendor_mobile_game/websocket/utils/json/Optional.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/utils/json/Optional.java
@@ -1,5 +1,11 @@
 package com.github.splendor_mobile_game.websocket.utils.json;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 public @interface Optional {
 
 }


### PR DESCRIPTION
Previously when you sent the request to the server and didn't attach the data field to it and in the same time the reaction you were targeting didn't define class with `@DataClass` annotation, so it was right not to send data in the request, it's not necessary. However, you would get an error, because you didn't provide the necessary field `data`. Stupid, right?

Now if dataclass is not defined and you send no data field in the request you don't get an error. 

Additionally if dataclass is not defined and you send the data field, then on the server's console warning will show up, telling you that the user send the data, that is not necessary.