### PR TITLE
Fix typo in EnvConfig constructor

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/config/EnvConfig.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/config/EnvConfig.java
@@ -19,7 +19,7 @@ public class EnvConfig implements Config {
     private String logsDir;
 
     public EnvConfig() throws InvalidConfigException {
-        this("./env");
+        this("./.env");
     }
 
     public EnvConfig(String dotEnvPath) throws InvalidConfigException {


### PR DESCRIPTION
@Antonidass5 has found a typo in the EnvConfig. The default constructor was set to load the file `env` when there is no such file. I have fixed it and now it looks for `.env` file.