### PR TITLE
Check for missing request type and log error

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/handlers/ReactionManager.java
@@ -143,6 +143,14 @@ public class ReactionManager {
                 reactionNameString = reactionNameAnnotation.value();
             }
 
+            try {
+                UserRequestType.valueOf(reactionNameString);
+            } catch (IllegalArgumentException e) {
+                Log.ERROR("Class `" + clazz.getName() + "` has ReactionName=" + reactionNameString + 
+                    ", but no mathing variant in UserRequestType has been found!"
+                );
+            }
+
             // Add the reaction to the map
             this.reactions.put(reactionNameString, reactionClass);
             Log.INFO("Class `" + clazz.getName() + "` loaded as `" + reactionNameString + "`");


### PR DESCRIPTION
It's highly possible that you may forget to add a new variant to the `UserRequestType` enum when adding a new reaction. To address this issue, I have implemented a check to ensure that the appropriate variant is included in the enum. If a variant is missing, an error message will be logged to remind the developer to add it.

For instance, let's say you added the `LeaveRoom` reaction but forgot to add the corresponding variant to the `UserRequestType` enum. The result would be the error shown in the following image:
![image](https://user-images.githubusercontent.com/40665452/229906574-5dd15c46-2fca-4b4b-a34a-e89bcbd43ebc.png)
 