### PR TITLE
Refactor and document ServerMessage

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/ServerMessage.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/ServerMessage.java
@@ -5,41 +5,70 @@ import java.util.UUID;
 import com.github.splendor_mobile_game.websocket.handlers.ServerMessageType;
 import com.github.splendor_mobile_game.websocket.response.Result;
 import com.github.splendor_mobile_game.websocket.utils.json.JsonParser;
+import com.github.splendor_mobile_game.websocket.utils.json.Optional;
 import com.github.splendor_mobile_game.websocket.utils.json.exceptions.JsonParserException;
 
-// TODO: Java doc required
+/**
+ * Represents a message sent by the server to the client.
+ */
 public class ServerMessage {
-    private UUID messageContextId;
+    
+    private UUID contextId;
+    
     private ServerMessageType type;
+    
     private Result result;
-    // @Optional
+    
+    @Optional
     private Object data;
 
-    public ServerMessage(String message) throws InvalidReceivedMessage {
-        ServerMessage msg = ServerMessage.fromJson(message);
-        this.messageContextId = msg.messageContextId;
+    /**
+     * Constructs a ServerMessage object from a JSON string.
+     * Heavly used on the client side.
+     * 
+     * @param json the JSON string representing the message
+     * @throws InvalidReceivedMessage if the json string does not represent the ServerMessage object.
+     */
+    public ServerMessage(String json) throws InvalidReceivedMessage {
+        ServerMessage msg = ServerMessage.fromJson(json);
+        this.contextId = msg.contextId;
         this.type = msg.type;
         this.result = msg.result;
         this.data = msg.getData();
     }
 
-    public ServerMessage(UUID messageContextId, ServerMessageType type, Result result, Object data) {
-        this.messageContextId = messageContextId;
+    /**
+     * Constructs a ServerMessage object with the specified parameters.
+     * 
+     * @param contextId the UUID of the message context
+     * @param type the type of the message
+     * @param result the result of the message
+     * @param data the data of the message (optional)
+     */
+    public ServerMessage(UUID contextId, ServerMessageType type, Result result, Object data) {
+        this.contextId = contextId;
         this.type = type;
         this.result = result;
         this.data = data;
     }
 
-    public static ServerMessage fromJson(String inputJson) throws InvalidReceivedMessage {
+    /**
+     * Parses a JSON string into a ServerMessage object.
+     * 
+     * @param json the JSON string to parse
+     * @return the ServerMessage object
+     * @throws InvalidReceivedMessage if the received message is invalid
+     */
+    private static ServerMessage fromJson(String json) throws InvalidReceivedMessage {
         try {
-            return JsonParser.parseJson(inputJson, ServerMessage.class);
+            return JsonParser.parseJson(json, ServerMessage.class);
         } catch (JsonParserException e) {
             throw new InvalidReceivedMessage("Received message is invalid!", e);
         }
     }
 
-    public UUID getMessageContextId() {
-        return messageContextId;
+    public UUID getContextId() {
+        return contextId;
     }
 
     public ServerMessageType getType() {
@@ -53,4 +82,5 @@ public class ServerMessage {
     public void setData(Object data) {
         this.data = data;
     }
+
 }


### PR DESCRIPTION
Now ServerMessage class is documented with java docs. 

- Also changed `messageContextId` field to just `contextId`. 
- `data` field is optional, so parsing json from the server ono the client that does not have data should be fine. `data` would be null then, I think.