### PR TITLE
Improve find class with annotation

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
@@ -181,7 +181,7 @@ public class WebSocketSplendorServer extends WebSocketServer {
         }
 
         // Parse the data given in the message
-        Class<?> dataClass = Reflection.findClassWithAnnotationWithinClass(reactionClass, DataClass.class);
+        Class<?> dataClass = Reflection.findFirstClassWithAnnotationWithinClass(reactionClass, DataClass.class);
 
         if (dataClass == null && receivedMessage.getData() != null) {
             Log.WARNING(connection.hashCode() + 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
@@ -108,6 +108,19 @@ public class Reflection {
         return annotatedClasses;
     }
 
+    // TODO: This function can be unit tested
+    /**
+     * Finds the first (alphabetically) nested class within a class that is annotated with a specific annotation.
+     *
+     * @param parent the class to search within
+     * @param annotation the annotation to search for
+     * @return the first nested class that is annotated with the specified annotation, or null if no such class exists
+     */
+    public static Class<?> findFirstClassWithAnnotationWithinClass(Class<?> parent, Class<? extends Annotation> annotation) {
+        List<Class<?>> annotatedClasses = findClassesWithAnnotationWithinClass(parent, annotation);
+        if (!annotatedClasses.isEmpty()) {
+            return annotatedClasses.get(0);
+        }
         return null;
     }
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/utils/reflection/Reflection.java
@@ -2,6 +2,8 @@ package com.github.splendor_mobile_game.websocket.utils.reflection;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.github.splendor_mobile_game.websocket.utils.Log;
 
@@ -88,16 +90,23 @@ public class Reflection {
 
     // TODO: This function can be unit tested
     /**
-     * Finds a nested class within a class that is annotated with a specific annotation.
-     * 
-     * @param parent     the class to search within
+     * Finds all nested classes within a class that are annotated with a specific annotation.
+     *
+     * @param parent the class to search within
      * @param annotation the annotation to search for
-     * @return the nested class that is annotated with the specified annotation, or null if no such class exists
+     * @return a list of nested classes that are annotated with the specified annotation, or an empty list if no such classes exist
      */
-    public static Class<?> findClassWithAnnotationWithinClass(Class<?> parent, Class<? extends Annotation> annotation) {
-        for (Class<?> clazz : parent.getDeclaredClasses())
-            if (clazz.isAnnotationPresent(annotation))
-                return clazz;
+    public static List<Class<?>> findClassesWithAnnotationWithinClass(Class<?> parent, Class<? extends Annotation> annotation) {
+        List<Class<?>> annotatedClasses = new ArrayList<>();
+
+        for (Class<?> clazz : parent.getDeclaredClasses()) {
+            if (clazz.isAnnotationPresent(annotation)) {
+                annotatedClasses.add(clazz);
+            }
+        }
+        
+        return annotatedClasses;
+    }
 
         return null;
     }


### PR DESCRIPTION
@Marczewka let me know that current implementation of `findClassWithAnnotationWithinClass` can bew vaguely interpreted to be unit tested. 

I propose changes now this function is split into two other methods:
- `findClassesWithAnnotationWithinClass` which returns a list of all found classes
- `findFirstClassWithAnnotationWithinClass` which returns only the first occurence (it uses the `findClassesWithAnnotationWithinClass` under the hood)