### PR TITLE
Fix/user independence

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/game/model/User.java
+++ b/src/main/java/com/github/splendor_mobile_game/game/model/User.java
@@ -183,11 +183,11 @@ public class User {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return name.equals(user.name) && uuid.equals(user.uuid) && connectionHasCode == user.getConnectionHashCode();
+        return uuid.equals(user.uuid) && connectionHasCode == user.getConnectionHashCode();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, uuid, connectionHasCode);
+        return Objects.hash(uuid, connectionHasCode);
     }
 }


### PR DESCRIPTION
Since users can have the same name in different rooms, we should be strict when overriding `.equals()` method. Removed `name` property from equals() method, so when it is used, it won't cause problems.