### PR TITLE
Better error messages when user forgot to provide some field

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/UserMessage.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/UserMessage.java
@@ -59,7 +59,7 @@ public class UserMessage {
             // TODO: Perfomance loss because of redundant json parsing
             this.data = JsonParser.parseJson((new Gson()).toJson(this.data), clazz);
         } catch (JsonParserException e) {
-            throw new InvalidReceivedMessage("Received message is invalid!", e);
+            throw new InvalidReceivedMessage("Received message is invalid <= " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/communication/WebSocketSplendorServer.java
@@ -169,7 +169,7 @@ public class WebSocketSplendorServer extends WebSocketServer {
             connection.send(customException.toJsonResponse());
 
         } catch (Exception exception) {
-            Log.ERROR("Server error: " + exception.getMessage() + "\n" + ExceptionUtils.getStackTrace(exception));
+            Log.ERROR(exception.getMessage());
             ErrorResponse response = new ErrorResponse(Result.ERROR, exception.getMessage() + "\n" + ExceptionUtils.getStackTrace(exception));
             connection.send(response.ToJson());
         }

--- a/src/main/java/com/github/splendor_mobile_game/websocket/utils/CustomException.java
+++ b/src/main/java/com/github/splendor_mobile_game/websocket/utils/CustomException.java
@@ -10,7 +10,7 @@ import com.github.splendor_mobile_game.websocket.response.Result;
  */
 public class CustomException extends RuntimeException {
 
-    private Result result = Result.ERROR;
+    private Result result = Result.FAILURE;
 
     public CustomException() {
     }
@@ -44,7 +44,7 @@ public class CustomException extends RuntimeException {
 
     @Override
     public String toString() {
-        return this.getMessage() + "\n" + ExceptionUtils.getStackTrace(this);
+        return this.getMessage();
     }
 
     /**


### PR DESCRIPTION
Then:
```json
{
    "contextId": "80bdc250-5365-4caf-8dd9-a33e709a0116",
    "type": "CREATE_ROOM_RESPONSE",
    "result": "FAILURE",
    "data": {
        "error": "Cannot invoke \"java.lang.CharSequence.length()\" because \"this.text\" is null"
    }
}
```

Now:
```json
{
    "contextId": "9e323af1-aa4f-4a59-92ec-ba8bfaf64f4c",
    "type": "ERROR",
    "result": "FAILURE",
    "data": {
        "error": "Received message is invalid <= Missing required field: password"
    }
}
```