### PR TITLE
Incorrect player starting turn fix

### DIFF
--- a/src/main/java/com/github/splendor_mobile_game/game/model/Room.java
+++ b/src/main/java/com/github/splendor_mobile_game/game/model/Room.java
@@ -131,6 +131,7 @@ public class Room {
 
     public void setOwner(User owner) {
         this.owner = owner;
+        this.currentOrder = owner;
     }
 
     public Game getGame() {


### PR DESCRIPTION
After the first owner leaves, the new owner is also set as a player with the first turn.